### PR TITLE
Handle unsatisfiable [empty] ranges

### DIFF
--- a/test/02-basic-find-test.py
+++ b/test/02-basic-find-test.py
@@ -258,3 +258,12 @@ class BasicFindTests(mango.UserDocsTests):
             })
         assert len(docs) == 1
         assert docs[0]["user_id"] == "eo"
+
+    def test_unsatisfiable_range(self):
+        docs = self.db.find({
+                "$and":[
+                    {"age":{"$gt": 0}},
+                    {"age":{"$lt": 0}}
+                ]
+            })
+        assert len(docs) == 0


### PR DESCRIPTION
Queries sometimes contain unsatisfiable ranges (i.e x < 0 and x > 0).
This is indicated by the [empty] value. In this case, we should not
perform a search and simply return 0 documents.

Fixes COUCHDB-2614
