### PR TITLE
Use different comparison function

### DIFF
--- a/src/mango_json.erl
+++ b/src/mango_json.erl
@@ -49,7 +49,7 @@ cmp(?MAX_VAL, _) ->
 cmp(_, ?MAX_VAL) ->
     -1;
 cmp(A, B) ->
-    couch_ejson_compare:less_json(A, B).
+    couch_ejson_compare:less(A, B).
 
 
 cmp_raw(?MIN_VAL, ?MIN_VAL) ->


### PR DESCRIPTION
Our mango_json:cmp/2 function used couch_ejson_compare:less_json.
That function returned a boolean value, but we need a number.
Documents were not returned and tests were failing. Changed function
to use couch_ejson_compare:less instead. Tests now pass.

Fixes COUCHDB-2622
