### PR TITLE
Return DDoc Id And Index Name

### DIFF
--- a/src/mango_httpd.erl
+++ b/src/mango_httpd.erl
@@ -20,6 +20,7 @@
 
 -include_lib("couch/include/couch_db.hrl").
 -include("mango.hrl").
+-include("mango_idx.hrl").
 
 
 handle_req(#httpd{} = Req, Db0) ->
@@ -58,6 +59,8 @@ handle_index_req(#httpd{method='POST', path_parts=[_, _]}=Req, Db) ->
     {ok, Idx0} = mango_idx:new(Db, Opts),
     {ok, Idx} = mango_idx:validate(Idx0),
     {ok, DDoc} = mango_util:load_ddoc(Db, mango_idx:ddoc(Idx)),
+    Id = Idx#idx.ddoc,
+    Name = Idx#idx.name,
     Status = case mango_idx:add(DDoc, Idx) of
         {ok, DDoc} ->
             <<"exists">>;
@@ -75,7 +78,7 @@ handle_index_req(#httpd{method='POST', path_parts=[_, _]}=Req, Db) ->
                     ?MANGO_ERROR(error_saving_ddoc)
             end
     end,
-	chttpd:send_json(Req, {[{result, Status}]});
+	chttpd:send_json(Req, {[{result, Status}, {id, Id}, {name, Name}]});
 
 handle_index_req(#httpd{method='DELETE',
         path_parts=[A, B, <<"_design">>, DDocId0, Type, Name]}=Req, Db) ->

--- a/test/mango.py
+++ b/test/mango.py
@@ -96,6 +96,8 @@ class Database(object):
         body = json.dumps(body)
         r = self.sess.post(self.path("_index"), data=body)
         r.raise_for_status()
+        assert r.json()["id"] is not None
+        assert r.json()["name"] is not None
         return r.json()["result"] == "created"
 
     def create_text_index(self, analyzer=None, selector=None, idx_type="text",
@@ -176,7 +178,7 @@ class DbPerClass(unittest.TestCase):
 
     @classmethod
     def setUpClass(klass):
-        klass.db = Database("127.0.0.1", "5984", random_db_name())
+        klass.db = Database("127.0.0.1", "15984", random_db_name())
         klass.db.create(q=1, n=3)
 
     def setUp(self):


### PR DESCRIPTION
We return the ddoc id and index name for easier deletion
from the dashboard. We don't return the full design doc because
we want to hide that abstraction of dealing with design docs from
the user.

FIXES COUCHDB-2645
