### PR TITLE
Enable Bulk Deletes

### DIFF
--- a/src/mango_error.erl
+++ b/src/mango_error.erl
@@ -110,6 +110,13 @@ info(mango_idx_view, {index_not_found, BadIdx}) ->
         fmt("JSON index ~s not found in this design doc.", [BadIdx])
     };
 
+info(mango_opts, {invalid_bulk_docs, Val}) ->
+    {
+        400,
+        <<"invalid_bulk_docs">>,
+        fmt("Bulk Delete requires an array of non-null docids. Docids: ~w",
+            [Val])
+    };
 info(mango_opts, {invalid_ejson, Val}) ->
     {
         400,

--- a/test/01-index-crud-test.py
+++ b/test/01-index-crud-test.py
@@ -150,6 +150,36 @@ class IndexCrudTests(mango.DbPerClass):
         post_indexes = self.db.list_indexes()
         assert pre_indexes == post_indexes
 
+    def test_bulk_delete(self):
+        fields = ["field1"]
+        ret = self.db.create_index(fields, name="idx_01")
+        assert ret is True
+
+        fields = ["field2"]
+        ret = self.db.create_index(fields, name="idx_02")
+        assert ret is True
+
+        fields = ["field3"]
+        ret = self.db.create_index(fields, name="idx_03")
+        assert ret is True
+
+        docids = []
+
+        for idx in self.db.list_indexes():
+            if idx["ddoc"] is not None:
+                docids.append(idx["ddoc"])
+
+        docids.append("_design/this_is_not_an_index_name")
+
+        ret = self.db.bulk_delete(docids)
+
+        assert ret["fail"][0]["id"] == "_design/this_is_not_an_index_name"
+        assert len(ret["success"]) == 3
+
+        for idx in self.db.list_indexes():
+            assert idx["type"] != "json"
+            assert idx["type"] != "text"
+
     def test_recreate_index(self):
         pre_indexes = self.db.list_indexes()
         for i in range(5):

--- a/test/mango.py
+++ b/test/mango.py
@@ -135,6 +135,15 @@ class Database(object):
         r = self.sess.delete(self.path(path), params={"w":"3"})
         r.raise_for_status()
 
+    def bulk_delete(self, docs):
+        body = {
+            "docids" : docs,
+            "w": 3
+        }
+        body = json.dumps(body)
+        r = self.sess.post(self.path("_index/_bulk_delete"), data=body)
+        return r.json()
+
     def find(self, selector, limit=25, skip=0, sort=None, fields=None,
                 r=1, conflicts=False, use_index=None, explain=False,
                 bookmark=None, return_raw=False):


### PR DESCRIPTION
Add _bulk_delete path to _index so that users can bulk delete
indexes via POST. Users will pass in a list of docids via the POST body.
We delete each index one by one until an error is thrown or all indexes
in the list are deleted.

Fixes COUCHDB-2651