### PR TITLE
Remove write quorum

### DIFF
--- a/src/mango_idx.erl
+++ b/src/mango_idx.erl
@@ -316,6 +316,8 @@ filter_opts([{name, _} | Rest]) ->
     filter_opts(Rest);
 filter_opts([{type, _} | Rest]) ->
     filter_opts(Rest);
+filter_opts([{w, _} | Rest]) ->
+    filter_opts(Rest);
 filter_opts([Opt | Rest]) ->
     [Opt | filter_opts(Rest)].
 


### PR DESCRIPTION
The write quorum is saved in the index. We cosmetically remove it.

Fixes:COUCHDB-2663
