### PR TITLE
Add support for index pagination

### DIFF
--- a/src/mango_error.erl
+++ b/src/mango_error.erl
@@ -77,6 +77,12 @@ info(mango_httpd, {error_saving_ddoc, Reason}) ->
         <<"error_saving_ddoc">>,
         fmt("Unknown error while saving the design document: ~s", [Reason])
     };
+info(mango_httpd, invalid_list_index_params) ->
+    {
+        500,
+        <<"invalid_list_index_params">>,
+        <<"Index parameter ranges: limit > 1, skip > 0" >>
+    };
 
 info(mango_idx, {invalid_index_type, BadType}) ->
     {

--- a/test/01-index-crud-test.py
+++ b/test/01-index-crud-test.py
@@ -222,3 +222,33 @@ class IndexCrudTests(mango.DbPerClass):
             assert e.response.status_code == 404
         else:
             raise AssertionError("bad index delete")
+
+    def test_limit_skip_index(self):
+        fields = ["field1"]
+        ret = self.db.create_index(fields, name="idx_01")
+        assert ret is True
+
+        fields = ["field2"]
+        ret = self.db.create_index(fields, name="idx_02")
+        assert ret is True
+
+        fields = ["field3"]
+        ret = self.db.create_index(fields, name="idx_03")
+        assert ret is True
+
+        assert len(self.db.list_indexes(limit=2)) == 2
+        assert len(self.db.list_indexes(limit=5,skip=4)) == 2
+        assert len(self.db.list_indexes(skip=5)) == 1
+        assert len(self.db.list_indexes(skip=6)) == 0
+        assert len(self.db.list_indexes(skip=100)) == 0
+        assert len(self.db.list_indexes(limit=10000000)) == 6
+
+        try:
+            self.db.list_indexes(skip=-1)
+        except Exception, e:
+            assert e.response.status_code == 500
+
+        try:
+            self.db.list_indexes(limit=0)
+        except Exception, e:
+            assert e.response.status_code == 500

--- a/test/mango.py
+++ b/test/mango.py
@@ -125,8 +125,12 @@ class Database(object):
         r.raise_for_status()
         return r.json()["result"] == "created"
 
-    def list_indexes(self):
-        r = self.sess.get(self.path("_index"))
+    def list_indexes(self, limit="", skip=""):
+        if limit != "":
+            limit = "limit=" + str(limit)
+        if skip != "":
+            skip = "skip=" + str(skip)
+        r = self.sess.get(self.path("_index?"+limit+";"+skip))
         r.raise_for_status()
         return r.json()["indexes"]
 


### PR DESCRIPTION
We add limit and skip parameters to GET so that the dashboard
can utilize these parameters for pagination.

Fixes: COUCHDB-2652
