### PR TITLE
Fix Quoted Numbers

### DIFF
--- a/test/06-basic-text-test.py
+++ b/test/06-basic-text-test.py
@@ -585,3 +585,10 @@ class NumStringTests(mango.DbPerClass):
         if len(docs) == 2:
             if docs[0]["number_string"] != f:
                 assert docs[1]["number_string"] == f
+        q = {"number_string": f}
+        docs = self.db.find(q)
+        if len(docs) == 1:
+            assert docs[0]["number_string"] == f
+        if len(docs) == 2:
+            if docs[0]["number_string"] != f:
+                assert docs[1]["number_string"] == f


### PR DESCRIPTION
This fixes the bug where users querying with number strings would return 0 documents. I.e:
{"number" : "12"} would not return anything.
