### PR TITLE
Correctly handle unsupported HTTP methods per resource

### DIFF
--- a/src/mango_httpd.erl
+++ b/src/mango_httpd.erl
@@ -107,6 +107,9 @@ handle_index_req(#httpd{method='POST', path_parts=[_, _]}=Req, Db) ->
     end,
 	chttpd:send_json(Req, {[{result, Status}, {id, Id}, {name, Name}]});
 
+handle_index_req(#httpd{path_parts=[_, _]}=Req, _Db) ->
+    chttpd:send_method_not_allowed(Req, "GET,POST");
+
 %% Essentially we just iterate through the list of ddoc ids passed in and
 %% delete one by one. If an error occurs, all previous documents will be
 %% deleted, but an error will be thrown for the current ddoc id.
@@ -129,6 +132,10 @@ handle_index_req(#httpd{method='POST', path_parts=[_, <<"_index">>,
         end
     end, {[], []}, DDocs),
     chttpd:send_json(Req, {[{<<"success">>, Success}, {<<"fail">>, Fail}]});
+
+handle_index_req(#httpd{path_parts=[_, <<"_index">>,
+        <<"_bulk_delete">>]}=Req, _Db) ->
+    chttpd:send_method_not_allowed(Req, "POST");
 
 handle_index_req(#httpd{method='DELETE',
         path_parts=[A, B, <<"_design">>, DDocId0, Type, Name]}=Req, Db) ->
@@ -155,8 +162,8 @@ handle_index_req(#httpd{method='DELETE',
             ?MANGO_ERROR({error_saving_ddoc, Error})
     end;
 
-handle_index_req(Req, _Db) ->
-    chttpd:send_method_not_allowed(Req, "GET,POST,DELETE").
+handle_index_req(#httpd{path_parts=[_, _, _DDocId0, _Type, _Name]}=Req, _Db) ->
+    chttpd:send_method_not_allowed(Req, "DELETE").
 
 
 handle_explain_req(#httpd{method='POST'}=Req, Db) ->


### PR DESCRIPTION
This helps to avoid silly errors like:
```
$ http delete http://localhost:15984/db/_index
HTTP/1.1 405 Method Not Allowed
Allow: GET,POST,DELETE
Cache-Control: must-revalidate
Content-Length: 71
Content-Type: text/plain; charset=utf-8
Date: Mon, 12 Oct 2015 16:19:18 GMT
Server: CouchDB/0f81930 (Erlang OTP/18)
X-Couch-Request-ID: 0d9c37826e
X-CouchDB-Body-Time: 0

{"error":"method_not_allowed","reason":"Only GET,POST,DELETE allowed"}
```