### PR TITLE
Port Missed Commits

### DIFF
--- a/src/mango_cursor_text.erl
+++ b/src/mango_cursor_text.erl
@@ -35,7 +35,8 @@
     limit,
     skip,
     user_fun,
-    user_acc
+    user_acc,
+    fields
 }).
 
 
@@ -53,7 +54,6 @@ create(Db, Indexes, Selector, Opts0) ->
     Limit = erlang:min(DreyfusLimit, couch_util:get_value(limit, Opts, 50)),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
-
     {ok, #cursor{
         db = Db,
         index = Index,
@@ -101,7 +101,8 @@ execute(Cursor, UserFun, UserAcc) ->
         skip = Skip,
         query_args = QueryArgs,
         user_fun = UserFun,
-        user_acc = UserAcc
+        user_acc = UserAcc,
+        fields = Cursor#cursor.fields
     },
     try
         execute(CAcc)
@@ -184,11 +185,12 @@ handle_hit(CAcc0, Sort, Doc) ->
 
 
 apply_user_fun(CAcc, Doc) ->
+    FinalDoc = mango_fields:extract(Doc, CAcc#cacc.fields),
     #cacc{
         user_fun = UserFun,
         user_acc = UserAcc
     } = CAcc,
-    case UserFun({row, Doc}, UserAcc) of
+    case UserFun({row, FinalDoc}, UserAcc) of
         {ok, NewUserAcc} ->
             CAcc#cacc{user_acc = NewUserAcc};
         {stop, NewUserAcc} ->

--- a/src/mango_cursor_text.erl
+++ b/src/mango_cursor_text.erl
@@ -54,6 +54,7 @@ create(Db, Indexes, Selector, Opts0) ->
     Limit = erlang:min(DreyfusLimit, couch_util:get_value(limit, Opts, 50)),
     Skip = couch_util:get_value(skip, Opts, 0),
     Fields = couch_util:get_value(fields, Opts, all_fields),
+
     {ok, #cursor{
         db = Db,
         index = Index,

--- a/test/07-text-custom-field-list-test.py
+++ b/test/07-text-custom-field-list-test.py
@@ -118,3 +118,24 @@ class CustomFieldsTest(mango.UserDocsTextTests):
             raise Exception("Should have thrown an HTTPError")
         except:
             return
+
+    def test_filtered_search_fields(self):
+        docs = self.db.find({"age": 22}, fields = ["age", "location.state"])
+        assert len(docs) == 1
+        assert docs == [{"age": 22, "location": {"state": "Missouri"}}]
+
+        docs = self.db.find({"age": 22}, fields = ["age", "Random Garbage"])
+        assert len(docs) == 1
+        assert docs == [{"age": 22}]
+
+        docs = self.db.find({"age": 22}, fields = ["favorites"])
+        assert len(docs) == 1
+        assert docs == [{"favorites": ["Lisp", "Erlang", "Python"]}]
+
+        docs = self.db.find({"age": 22}, fields = ["favorites.[]"])
+        assert len(docs) == 1
+        assert docs == [{}]
+
+        docs = self.db.find({"age": 22}, fields = ["all_fields"])
+        assert len(docs) == 1
+        assert docs == [{}]


### PR DESCRIPTION
Port over two commits that were missed. This fixes the text index bug where a user specifies only a subset of fields, but still gets the entire document back.
