### PR TITLE
add prototype for mango catch-all feature

### DIFF
--- a/src/mango_cursor.erl
+++ b/src/mango_cursor.erl
@@ -16,7 +16,8 @@
 -export([
     create/3,
     explain/1,
-    execute/3
+    execute/3,
+    maybe_filter_indexes/2
 ]).
 
 
@@ -53,7 +54,8 @@ create(Db, Selector0, Opts) ->
         0 ->
             % fallback to _id > null for better usability
             NewSelector = {[{<<"$and">>, [Selector, {[{<<"_id">>, {[{<<"$gt">>, null}]}}]}]}]},
-            couch_log:notice("no matching index found, create an index to optimize query time", []),
+            couch_log:warning("no matching index found, create an index to optimize query time", []),
+            couch_log:warning("~p", [Opts]),
             create(Db, NewSelector, Opts);
         _ ->
             create_cursor(Db, UsableIndexes, Selector, Opts)

--- a/src/mango_cursor.erl
+++ b/src/mango_cursor.erl
@@ -39,10 +39,8 @@ create(Db, Selector0, Opts) ->
             ?MANGO_ERROR({no_usable_index, selector_unsupported});
         {0, 0} ->
             AllDocs = mango_idx:special(Db),
-            io:format("Index ~p~n", [AllDocs]),
             create_cursor(Db, AllDocs, Selector, Opts);
         _ ->
-            io:format("Index ~p~n", ["UsableIndexes"]),
             create_cursor(Db, UsableIndexes, Selector, Opts)
     end.
 
@@ -117,9 +115,9 @@ group_indexes_by_type(Indexes) ->
     % queries.
     CursorModules = case module_loaded(dreyfus_index) of
         true ->
-            [mango_cursor_view, mango_cursor_text];
+            [mango_cursor_view, mango_cursor_text, mango_cursor_special];
         false ->
-            [mango_cursor_view]
+            [mango_cursor_view, mango_cursor_special]
     end,
     lists:flatmap(fun(CMod) ->
         case dict:find(CMod, IdxDict) of

--- a/src/mango_cursor_special.erl
+++ b/src/mango_cursor_special.erl
@@ -58,4 +58,4 @@ execute(Cursor0, UserFun, UserAcc) ->
     mango_cursor_view:execute(Cursor0, UserFun, UserAcc).
 
 handle_message(Msg, Cursor) ->
-    mango_cursor_view:mango_cursor_view(Msg, Cursor).
+    mango_cursor_view:handle_message(Msg, Cursor).

--- a/src/mango_cursor_special.erl
+++ b/src/mango_cursor_special.erl
@@ -1,0 +1,61 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+% http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(mango_cursor_special).
+
+-export([
+    create/4,
+    explain/1,
+    execute/3
+]).
+
+-export([
+    handle_message/2
+]).
+
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch_mrview/include/couch_mrview.hrl").
+-include("mango_cursor.hrl").
+
+
+create(Db, Indexes, Selector, Opts) ->
+    InitialRange = mango_idx_view:field_ranges(Selector),
+    CatchAll = [{<<"_id">>, {'$gt', null, '$lt', mango_json_max}}],
+    FieldRanges = lists:append(CatchAll, InitialRange),
+    Composited = mango_cursor_view:composite_indexes(Indexes, FieldRanges),
+    {Index, IndexRanges} = mango_cursor_view:choose_best_index(Db, Composited),
+
+    Limit = couch_util:get_value(limit, Opts, 10000000000),
+    Skip = couch_util:get_value(skip, Opts, 0),
+    Fields = couch_util:get_value(fields, Opts, all_fields),
+
+    {ok, #cursor{
+        db = Db,
+        index = Index,
+        ranges = IndexRanges,
+        selector = Selector,
+        opts = Opts,
+        limit = Limit,
+        skip = Skip,
+        fields = Fields
+    }}.
+
+
+explain(Cursor) ->
+    mango_cursor_view:explain(Cursor).
+
+execute(Cursor0, UserFun, UserAcc) ->
+    mango_cursor_view:execute(Cursor0, UserFun, UserAcc).
+
+handle_message(Msg, Cursor) ->
+  mango_cursor_view:mango_cursor_view(Msg, Cursor).

--- a/src/mango_cursor_special.erl
+++ b/src/mango_cursor_special.erl
@@ -58,4 +58,4 @@ execute(Cursor0, UserFun, UserAcc) ->
     mango_cursor_view:execute(Cursor0, UserFun, UserAcc).
 
 handle_message(Msg, Cursor) ->
-  mango_cursor_view:mango_cursor_view(Msg, Cursor).
+    mango_cursor_view:mango_cursor_view(Msg, Cursor).

--- a/src/mango_cursor_view.erl
+++ b/src/mango_cursor_view.erl
@@ -66,6 +66,7 @@ explain(Cursor) ->
 
 
 execute(#cursor{db = Db, index = Idx} = Cursor0, UserFun, UserAcc) ->
+    io:format("execute cursor index ~p~n", [Idx]),
     Cursor = Cursor0#cursor{
         user_fun = UserFun,
         user_acc = UserAcc
@@ -75,6 +76,7 @@ execute(#cursor{db = Db, index = Idx} = Cursor0, UserFun, UserAcc) ->
             % empty indicates unsatisfiable ranges, so don't perform search
             {ok, UserAcc};
         _ ->
+            io:format("execute cursor index ~p~p~n", [Idx, Cursor#cursor.ranges]),
             BaseArgs = #mrargs{
                 view_type = map,
                 reduce = false,

--- a/src/mango_cursor_view.erl
+++ b/src/mango_cursor_view.erl
@@ -19,7 +19,9 @@
 ]).
 
 -export([
-    handle_message/2
+    handle_message/2,
+    composite_indexes/2,
+    choose_best_index/2
 ]).
 
 
@@ -66,7 +68,6 @@ explain(Cursor) ->
 
 
 execute(#cursor{db = Db, index = Idx} = Cursor0, UserFun, UserAcc) ->
-    io:format("execute cursor index ~p~n", [Idx]),
     Cursor = Cursor0#cursor{
         user_fun = UserFun,
         user_acc = UserAcc
@@ -76,7 +77,6 @@ execute(#cursor{db = Db, index = Idx} = Cursor0, UserFun, UserAcc) ->
             % empty indicates unsatisfiable ranges, so don't perform search
             {ok, UserAcc};
         _ ->
-            io:format("execute cursor index ~p~p~n", [Idx, Cursor#cursor.ranges]),
             BaseArgs = #mrargs{
                 view_type = map,
                 reduce = false,

--- a/src/mango_httpd.erl
+++ b/src/mango_httpd.erl
@@ -236,7 +236,7 @@ maybe_add_warning(Db, Selector, Opts) ->
     UsableIndexes = mango_idx:get_usable_indexes(Db, Selector, Opts),
     case length(UsableIndexes) of
         0 ->
-            "{\"_warning\":\"no matching index found, create an index to optimize query time\",\r\n\"docs\":[";
+            "{\"warning\":\"no matching index found, create an index to optimize query time\",\r\n\"docs\":[";
         _ ->
             "{\"docs\":["
     end.

--- a/src/mango_idx.erl
+++ b/src/mango_idx.erl
@@ -42,7 +42,8 @@
     cursor_mod/1,
     idx_mod/1,
     to_json/1,
-    delete/4
+    delete/4,
+    get_usable_indexes/3
 ]).
 
 
@@ -54,6 +55,27 @@
 list(Db) ->
     {ok, Indexes} = ddoc_cache:open(db_to_name(Db), ?MODULE),
     Indexes.
+
+get_usable_indexes(Db, Selector0, Opts) ->
+    Selector = mango_selector:normalize(Selector0),
+
+    ExistingIndexes = mango_idx:list(Db),
+    if ExistingIndexes /= [] -> ok; true ->
+        ?MANGO_ERROR({no_usable_index, no_indexes_defined})
+    end,
+
+    FilteredIndexes = mango_cursor:maybe_filter_indexes(ExistingIndexes, Opts),
+    if FilteredIndexes /= [] -> ok; true ->
+        ?MANGO_ERROR({no_usable_index, no_index_matching_name})
+    end,
+
+    SortIndexes = mango_idx:for_sort(FilteredIndexes, Opts),
+    if SortIndexes /= [] -> ok; true ->
+        ?MANGO_ERROR({no_usable_index, missing_sort_index})
+    end,
+
+    UsableFilter = fun(I) -> mango_idx:is_usable(I, Selector) end,
+    lists:filter(UsableFilter, SortIndexes).
 
 recover(Db) ->
     {ok, DDocs0} = mango_util:open_ddocs(Db),

--- a/src/mango_idx.erl
+++ b/src/mango_idx.erl
@@ -267,7 +267,7 @@ end_key(#idx{}=Idx, Ranges) ->
 cursor_mod(#idx{type = <<"json">>}) ->
     mango_cursor_view;
 cursor_mod(#idx{def = all_docs, type= <<"special">>}) ->
-    mango_cursor_view;
+    mango_cursor_special;
 cursor_mod(#idx{type = <<"text">>}) ->
     case module_loaded(dreyfus_index) of
         true ->

--- a/test/02-basic-find-test.py
+++ b/test/02-basic-find-test.py
@@ -236,12 +236,9 @@ class BasicFindTests(mango.UserDocsTests):
             assert len(docs) == 15
 
     def test_empty(self):
-        try:
-            self.db.find({})
-        except Exception, e:
-            assert e.response.status_code == 200
-        else:
-            raise AssertionError("bad find")
+        docs = self.db.find({})
+        # 15 users and 9 design docs
+        assert len(docs) == 24
 
     def test_empty_subsel(self):
         docs = self.db.find({

--- a/test/02-basic-find-test.py
+++ b/test/02-basic-find-test.py
@@ -239,7 +239,7 @@ class BasicFindTests(mango.UserDocsTests):
         try:
             self.db.find({})
         except Exception, e:
-            assert e.response.status_code == 400
+            assert e.response.status_code == 200
         else:
             raise AssertionError("bad find")
 

--- a/test/05-index-selection-test.py
+++ b/test/05-index-selection-test.py
@@ -74,6 +74,16 @@ class IndexSelectionTests(mango.UserDocsTests):
             }, use_index=ddocid, explain=True)
         assert resp["index"]["ddoc"] == ddocid
 
+    def test_use_most_columns(self):
+        # ddoc id for the age index
+        ddocid = "_design/ad3d537c03cd7c6a43cf8dff66ef70ea54c2b40f"
+        try:
+            self.db.find({}, use_index=ddocid)
+        except Exception, e:
+            assert e.response.status_code == 400
+        else:
+            raise AssertionError("bad find")
+
     # This doc will not be saved given the new ddoc validation code
     # in couch_mrview
     def test_manual_bad_view_idx01(self):


### PR DESCRIPTION
Hey,

this is a prototype which is not fully implemented yet. 

I want to find out if there is general interest and if it would be worth to spend more time.

The problem I am trying to solve is that I usually have a hard time explaining people how views work. Now we got Mango and I can just say: we use a syntax similar to MongoDB's query language *but you have to create an index before you can use it*. 

At this point I usually look into sad, big eyes because no one understands why they have to create an index first and I feel there is another entry barrier for newcomers.

The idea of this patch is to just fallback on the "give me all docs and i filter afterwards"-trick that people usually use (if they know it) when they just want to test something, without creating an index which can take time for creation and requires further knowledge. Additionally the user is warned that they can create an index to make the queries faster.