### PR TITLE
Add Op_field Term To Fix Special $or Case

### DIFF
--- a/src/mango_idx_text.erl
+++ b/src/mango_idx_text.erl
@@ -294,7 +294,7 @@ indexable_fields(Fields, {op_or, [{op_field, Field0},
         true ->
             indexable_fields(Fields, Field1);
         false ->
-            Fields1 = indexable_fields(Fields, Field0),
+            Fields1 = indexable_fields(Fields, {op_field, Field0}),
             indexable_fields(Fields1, Field1)
     end;
 indexable_fields(Fields, {op_or, Args}) when is_list(Args) ->

--- a/test/07-text-custom-field-list-test.py
+++ b/test/07-text-custom-field-list-test.py
@@ -139,3 +139,9 @@ class CustomFieldsTest(mango.UserDocsTextTests):
         docs = self.db.find({"age": 22}, fields = ["all_fields"])
         assert len(docs) == 1
         assert docs == [{}]
+
+    def test_two_or(self):
+        docs = self.db.find({"$or": [{"location.state": "New Hampshire"},
+            {"location.state": "Don't Exist"}]})
+        assert len(docs) == 1
+        assert docs[0]["user_id"] == 10


### PR DESCRIPTION
We're missing the term op_field when recursively calling
indexable_fields in a special case. This leads to a function_clause
error when specifically two elements are used in a $or query. It works
when they index all fields because indexable_fields is not called.
However, when the user specifically indexes a field, we encounter this
error. Inserting the op_field term  allows the function to be called
correctly.
