### PR TITLE
Set default limit to 25

### DIFF
--- a/src/mango_cursor.hrl
+++ b/src/mango_cursor.hrl
@@ -16,7 +16,7 @@
     ranges,
     selector,
     opts,
-    limit = 10000000000,
+    limit = 25,
     skip = 0,
     fields = undefined,
     user_fun,

--- a/src/mango_opts.erl
+++ b/src/mango_opts.erl
@@ -93,7 +93,7 @@ validate_find({Props}) ->
         {<<"limit">>, [
             {tag, limit},
             {optional, true},
-            {default, 10000000000},
+            {default, 25},
             {validator, fun is_non_neg_integer/1}
         ]},
         {<<"skip">>, [

--- a/test/mango.py
+++ b/test/mango.py
@@ -27,7 +27,7 @@ def random_db_name():
     return "mango_test_" + uuid.uuid4().hex
 
 def has_text_service():
-    return os.path.isfile(os.getcwd() + "/../src/mango_cursor.erl")
+    return os.path.isfile(os.getcwd() + "/../src/mango_cursor_text.erl")
 
 
 class Database(object):


### PR DESCRIPTION
The docs claim the limit is 25 and this was the intention but this value
was never updated. The reason to set it at 25 is in case we add other
index types that are unable to stream results to the client (ie,
anything Lucene based). This allows us to maintain the same API across
all calls regardless of index type used.

COUCHDB-3143