### PR TITLE
Do Not Allow Empty Field Name

### DIFF
--- a/src/mango_error.erl
+++ b/src/mango_error.erl
@@ -152,7 +152,7 @@ info(mango_idx_text, {invalid_index_fields_definition, Def}) ->
         400,
         <<"invalid_index_fields_definition">>,
         fmt("Text Index field definitions must be of the form
-            {\"name\": \"fieldname\", \"type\":
+            {\"name\": \"non-empty fieldname\", \"type\":
                 \"boolean,number, or string\"}. Def: ~p", [Def])
     };
 info(mango_idx_view, {index_not_found, BadIdx}) ->

--- a/src/mango_sort.erl
+++ b/src/mango_sort.erl
@@ -47,6 +47,8 @@ directions({Props}) ->
     [Dir || {_Name, Dir} <- Props].
 
 
+sort_field(<<"">>) ->
+    ?MANGO_ERROR({invalid_sort_field, <<"">>});
 sort_field(Field) when is_binary(Field) ->
     {Field, <<"asc">>};
 sort_field({[{Name, <<"asc">>}]}) when is_binary(Name) ->

--- a/test/01-index-crud-test.py
+++ b/test/01-index-crud-test.py
@@ -26,7 +26,8 @@ class IndexCrudTests(mango.DbPerClass):
             {"foo": "bar"},
             [{"foo": 2}],
             [{"foo": "asc", "bar": "desc"}],
-            [{"foo": "asc"}, {"bar": "desc"}]
+            [{"foo": "asc"}, {"bar": "desc"}],
+            [""]
         ]
         for fields in bad_fields:
             try:
@@ -254,7 +255,8 @@ class IndexCrudTests(mango.DbPerClass):
             [{"name": "foo3", "type": "garbage"}],
             [{"type": "number"}],
             [{"name": "age", "type": "number"} , {"name": "bad"}],
-            [{"name": "age", "type": "number"} , "bla"]
+            [{"name": "age", "type": "number"} , "bla"],
+            [{"name": "", "type": "number"} , "bla"]
         ]
         for fields in bad_fields:
             try:


### PR DESCRIPTION
Currently, the indexer crashes when a field name is empty.

```
exception exit: {bad_return_value,
                        {mango_error,mango_util,{invalid_field_name,<<>>}}}
```

Even though it's valid json, we should disallow empty field names to coincide
with selector syntax that requires a non-empty field name for queries.

COUCHDB-3202
