### PR TITLE
Ignore design docs when using _all_docs

### DIFF
--- a/src/mango_cursor_view.erl
+++ b/src/mango_cursor_view.erl
@@ -171,13 +171,14 @@ handle_message(complete, Cursor) ->
 handle_message({error, Reason}, _Cursor) ->
     {error, Reason}.
 
+
 handle_all_docs_message({row, Props}, Cursor) ->
     case is_design_doc(Props) of
         true -> {ok, Cursor};
         false -> handle_message({row, Props}, Cursor)
     end;
-handle_all_docs_message(_Message, _Cursor) ->
-    handle_message(_Message, _Cursor).
+handle_all_docs_message(Message, Cursor) ->
+    handle_message(Message, Cursor).
 
 
 handle_doc(#cursor{skip = S} = C, _) when S > 0 ->
@@ -265,7 +266,6 @@ doc_member(Db, RowProps, Opts) ->
             end
     end.
 
-%do this check here as its only in the _all_docs that it returns design docs when we don't want it to
 is_design_doc(RowProps) ->
     case couch_util:get_value(id, RowProps) of
         <<"_design/", _/binary>> -> true;

--- a/src/mango_cursor_view.erl
+++ b/src/mango_cursor_view.erl
@@ -20,6 +20,7 @@
 
 -export([
     handle_message/2,
+    handle_all_docs_message/2,
     composite_indexes/2,
     choose_best_index/2
 ]).
@@ -85,11 +86,12 @@ execute(#cursor{db = Db, index = Idx} = Cursor0, UserFun, UserAcc) ->
                 include_docs = true
             },
             Args = apply_opts(Cursor#cursor.opts, BaseArgs),
-            CB = fun ?MODULE:handle_message/2,
             {ok, LastCursor} = case mango_idx:def(Idx) of
                 all_docs ->
+                    CB = fun ?MODULE:handle_all_docs_message/2,
                     fabric:all_docs(Db, CB, Cursor, Args);
                 _ ->
+                    CB = fun ?MODULE:handle_message/2,
                     % Normal view
                     DDoc = ddocid(Idx),
                     Name = mango_idx:name(Idx),
@@ -168,6 +170,14 @@ handle_message(complete, Cursor) ->
     {ok, Cursor};
 handle_message({error, Reason}, _Cursor) ->
     {error, Reason}.
+
+handle_all_docs_message({row, Props}, Cursor) ->
+    case is_design_doc(Props) of
+        true -> {ok, Cursor};
+        false -> handle_message({row, Props}, Cursor)
+    end;
+handle_all_docs_message(_Message, _Cursor) ->
+    handle_message(_Message, _Cursor).
 
 
 handle_doc(#cursor{skip = S} = C, _) when S > 0 ->
@@ -253,4 +263,11 @@ doc_member(Db, RowProps, Opts) ->
                 Else ->
                     Else
             end
+    end.
+
+%do this check here as its only in the _all_docs that it returns design docs when we don't want it to
+is_design_doc(RowProps) ->
+    case couch_util:get_value(id, RowProps) of
+        <<"_design/", _/binary>> -> true;
+        _ -> false
     end.

--- a/src/mango_selector.erl
+++ b/src/mango_selector.erl
@@ -59,7 +59,10 @@ match(Selector, #doc{body=Body}) ->
     match(Selector, Body, fun mango_json:cmp/2);
 
 match(Selector, {Props}) ->
-    match(Selector, {Props}, fun mango_json:cmp/2).
+    case mango_doc:get_field({Props}, <<"_id">>) of
+        <<"_design/", _/binary>> -> false;
+        _ -> match(Selector, {Props}, fun mango_json:cmp/2)
+    end.
 
 % Convert each operator into a normalized version as well
 % as convert an implict operators into their explicit

--- a/src/mango_selector.erl
+++ b/src/mango_selector.erl
@@ -59,10 +59,7 @@ match(Selector, #doc{body=Body}) ->
     match(Selector, Body, fun mango_json:cmp/2);
 
 match(Selector, {Props}) ->
-    case mango_doc:get_field({Props}, <<"_id">>) of
-        <<"_design/", _/binary>> -> false;
-        _ -> match(Selector, {Props}, fun mango_json:cmp/2)
-    end.
+    match(Selector, {Props}, fun mango_json:cmp/2).
 
 % Convert each operator into a normalized version as well
 % as convert an implict operators into their explicit

--- a/test/02-basic-find-test.py
+++ b/test/02-basic-find-test.py
@@ -237,8 +237,8 @@ class BasicFindTests(mango.UserDocsTests):
 
     def test_empty(self):
         docs = self.db.find({})
-        # 15 users and 9 design docs
-        assert len(docs) == 24
+        # 15 users 
+        assert len(docs) == 15
 
     def test_empty_subsel(self):
         docs = self.db.find({

--- a/test/11-ignore-design-docs.py
+++ b/test/11-ignore-design-docs.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import mango
+import unittest
+
+DOCS = [
+    {
+        "_id": "_design/my-design-doc",
+    },
+    {
+        "_id": "54af50626de419f5109c962f",
+        "user_id": 0,
+        "age": 10,
+        "name": "Jimi"
+    },
+    {
+        "_id": "54af50622071121b25402dc3",
+        "user_id": 1,
+        "age": 11,
+        "name": "Eddie"
+    }
+]
+
+class IgnoreDesignDocsForAllDocsIndexTests(mango.DbPerClass):
+    def test_should_not_return_design_docs(self):
+        self.db.save_docs(DOCS)
+        docs = self.db.find({"_id": {"$gte": None}})
+        assert len(docs) == 2
+


### PR DESCRIPTION
This stops design docs from being returned when using the special
all_docs index