### PR TITLE
Use gb_sets to create unique list

### DIFF
--- a/src/mango_native_proc.erl
+++ b/src/mango_native_proc.erl
@@ -175,7 +175,7 @@ get_text_entries0(IdxProps, Doc) ->
     Fields = if not DefaultEnabled -> Fields0; true ->
         add_default_text_field(Fields0)
     end,
-    FieldNames = get_field_names(Fields, []),
+    FieldNames = get_field_names(Fields),
     Converted = convert_text_fields(Fields),
     FieldNames ++ Converted.
 
@@ -257,15 +257,10 @@ add_default_text_field([_ | Rest], Acc) ->
 
 
 %% index of all field names
-get_field_names([], FAcc) ->
-    FAcc;
-get_field_names([{Name, _Type, _Value} | Rest], FAcc) ->
-    case lists:member([<<"$fieldnames">>, Name, []], FAcc) of
-        true ->
-            get_field_names(Rest, FAcc);
-        false ->
-            get_field_names(Rest, [[<<"$fieldnames">>, Name, []] | FAcc])
-    end.
+get_field_names(Fields) ->
+    GBFieldSet = gb_sets:from_list(Fields),
+    UFields = gb_sets:to_list(GBFieldSet),
+    [[<<"$fieldnames">>, Name, []] || {Name, _Type, _Value} <- UFields].
 
 
 convert_text_fields([]) ->


### PR DESCRIPTION
When indexing a set of fields for text search, we also create a special
field called $fieldnames. It contains values for all the fields that
need to be indexed. In order to do that, we need a unique list of the
form [[<<"$fieldnames">>, Name, [] | Rest]. The old code would add an
element to the list, and then check for membership via lists:member/2.
This is inefficient. Some documents can contain a large number of
fields, so we will use gb_sets to create a unique set of fields, and
then extract out the field names.

Note that we can also  just do lists:usort, but gb_sets work better for large data sets.
With gb_sets, it might be slower for small number of the same fields, so that would imply
indexing would take longer, but we won't be bottlenecked with one huge document.

Regression Run of tests showed no regressions.
COUCHDB-3358